### PR TITLE
[EVMC][SSVM] Update evmc and ssvm-evmc version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/second-state/rust-ssvm/"
 build="build.rs"
 
 [dependencies]
-evmc-client = { git = "https://github.com/second-state/evmc", tag = "v7.4.0-rust-evmc-client-rc.1" }
+evmc-client = { git = "https://github.com/second-state/evmc", tag = "v7.4.0-rust-evmc-client-rc.2" }
 libloading = "0.5"
 hex = "0.4"
 clap = "2.33.0"

--- a/examples/execute_vm.rs
+++ b/examples/execute_vm.rs
@@ -113,6 +113,7 @@ impl HostInterface for HostContext {
         _gas: i64,
         _depth: i32,
         _is_static: bool,
+        _salt: &Bytes32,
     ) -> (Vec<u8>, i64, Address, StatusCode) {
         println!("Host: call");
         return (
@@ -162,9 +163,9 @@ fn main() {
     println!("Instantiate: {:?}", (_vm.get_name(), _vm.get_version()));
     match read_a_file(file_path) {
         Ok(code) => {
-            let host_context = HostContext::new();
+            let mut host_context = HostContext::new();
             let (output, gas_left, status_code) = _vm.execute(
-                Box::new(host_context),
+                &mut host_context,
                 Revision::EVMC_BYZANTIUM,
                 MessageKind::EVMC_CALL,
                 false,


### PR DESCRIPTION
1. migrate evmc version for fix lifetime potential issues.
2. ssvm-evmc regular upgrade.