### PR TITLE
Prepare release for pallet-ssvm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-ssvm"
-version = "0.0.1"
+version = "0.0.2"
 license = "AGPL-3.0"
 authors = ["SecondState"]
 description = "Rust-SSVM - a Portable EWASM Engine Binding Rust Interface"
@@ -9,10 +9,10 @@ repository = "https://github.com/second-state/rust-ssvm/"
 build="build.rs"
 
 [dependencies]
-evmc-client = { git = "https://github.com/second-state/evmc", tag = "v7.4.0-rust-evmc-client-rc.2" }
+evmc-client = { version = "7.4.1", package="ssvm-evmc-client" }
 libloading = "0.5"
 hex = "0.4"
 clap = "2.33.0"
 
 [build-dependencies]
-cmake = "0.1.42"
+cmake = "0.1.44"


### PR DESCRIPTION
See [pallet-ssvm#9](https://github.com/second-state/pallet-ssvm/pull/9)

Related versions on crates:
  * [rust-ssvm](https://crates.io/crates/rust-ssvm) on [crates.io]
    - `0.0.1` *YANKED*
    - forked from `master` = `dc7d33abe6e936ff8dc5e8013c8fedcdf3dd0d54`
      * `0.0.2` depends on `ssvm-evmc-client@7.4.1` *YANKED*
    - forked from `v0.0.1+3` = `3b8953adbd1647751aefda8dda57adf5dd33ae95`
      * `0.0.3` depends on `ssvm-evmc-client@7.4.1` *YANKED*